### PR TITLE
NULL repeated fields should be converted to an empty list

### DIFF
--- a/src/protobuf2json.c
+++ b/src/protobuf2json.c
@@ -302,6 +302,21 @@ static int protobuf2json_process_message(
           );
         }
       }
+      else {
+        json_t *array = json_array();
+        if (!array) {
+          SET_ERROR_STRING_AND_RETURN(
+            PROTOBUF2JSON_ERR_CANNOT_ALLOCATE_MEMORY,
+            "Cannot allocate JSON structure using json_array()"
+          );
+        }
+        if (json_object_set_new(*json_message, field_descriptor->name, array)) {
+          SET_ERROR_STRING_AND_RETURN(
+            PROTOBUF2JSON_ERR_JANSSON_INTERNAL,
+            "Error in json_object_set_new()"
+          );
+        }
+      }
     }
   }
 

--- a/test/run-tmp.c
+++ b/test/run-tmp.c
@@ -346,7 +346,8 @@ void read_file_success(void) {
     json_string,
     "{\n"
     "  \"name\": \"John Doe\",\n"
-    "  \"id\": 42\n"
+    "  \"id\": 42,\n"
+    "  \"phone\": []\n"
     "}"
   );
 

--- a/test/test-json2protobuf-file.c
+++ b/test/test-json2protobuf-file.c
@@ -40,7 +40,8 @@ TEST_IMPL(json2protobuf_file__success) {
     json_string,
     "{\n"
     "  \"name\": \"John Doe\",\n"
-    "  \"id\": 42\n"
+    "  \"id\": 42,\n"
+    "  \"phone\": []\n"
     "}"
   );
 

--- a/test/test-protobuf2json-file.c
+++ b/test/test-protobuf2json-file.c
@@ -57,7 +57,8 @@ TEST_IMPL(protobuf2json_file__success) {
     json_string,
     "{\n"
     "  \"name\": \"John Doe\",\n"
-    "  \"id\": 42\n"
+    "  \"id\": 42,\n"
+    "  \"phone\": []\n"
     "}"
   );
 

--- a/test/test-protobuf2json-string.c
+++ b/test/test-protobuf2json-string.c
@@ -29,7 +29,8 @@ TEST_IMPL(protobuf2json_string__required_field) {
     json_string,
     "{\n"
     "  \"name\": \"John Doe\",\n"
-    "  \"id\": 42\n"
+    "  \"id\": 42,\n"
+    "  \"phone\": []\n"
     "}"
   );
 
@@ -58,7 +59,8 @@ TEST_IMPL(protobuf2json_string__optional_field) {
     "{\n"
     "  \"name\": \"John Doe\",\n"
     "  \"id\": 42,\n"
-    "  \"email\": \"john@doe.name\"\n"
+    "  \"email\": \"john@doe.name\",\n"
+    "  \"phone\": []\n"
     "}"
   );
 

--- a/test/test-reversible.c
+++ b/test/test-reversible.c
@@ -292,7 +292,11 @@ TEST_IMPL(reversible__numbers) {
     "    true,\n"
     "    false,\n"
     "    false\n"
-    "  ]\n"
+    "  ],\n"
+    "  \"value_enum\": [],\n"
+    "  \"value_string\": [],\n"
+    "  \"value_bytes\": [],\n"
+    "  \"value_message\": []\n"
 
     "}"
   ;
@@ -339,11 +343,27 @@ TEST_IMPL(reversible__strings) {
 
   const char *expected_json_string = \
     "{\n"
+    "  \"value_int32\": [],\n"
+    "  \"value_sint32\": [],\n"
+    "  \"value_sfixed32\": [],\n"
+    "  \"value_uint32\": [],\n"
+    "  \"value_fixed32\": [],\n"
+    "  \"value_int64\": [],\n"
+    "  \"value_sint64\": [],\n"
+    "  \"value_sfixed64\": [],\n"
+    "  \"value_uint64\": [],\n"
+    "  \"value_fixed64\": [],\n"
+    "  \"value_float\": [],\n"
+    "  \"value_double\": [],\n"
+    "  \"value_bool\": [],\n"
+    "  \"value_enum\": [],\n"
     "  \"value_string\": [\n"
     "    \"qwerty \",\n"                    /* Note: \0-byte terminated string */
     "    \"qwerty \",\n"                    /* Note: \0-byte terminated string */
     "    \"\"\n"                            /* Note: \0-byte terminated string */
-    "  ]\n"
+    "  ],\n"
+    "  \"value_bytes\": [],\n"
+    "  \"value_message\": []\n"
     "}"
   ;
 
@@ -400,12 +420,28 @@ TEST_IMPL(reversible__bytes) {
 
   const char *expected_json_string = \
     "{\n"
+    "  \"value_int32\": [],\n"
+    "  \"value_sint32\": [],\n"
+    "  \"value_sfixed32\": [],\n"
+    "  \"value_uint32\": [],\n"
+    "  \"value_fixed32\": [],\n"
+    "  \"value_int64\": [],\n"
+    "  \"value_sint64\": [],\n"
+    "  \"value_sfixed64\": [],\n"
+    "  \"value_uint64\": [],\n"
+    "  \"value_fixed64\": [],\n"
+    "  \"value_float\": [],\n"
+    "  \"value_double\": [],\n"
+    "  \"value_bool\": [],\n"
+    "  \"value_enum\": [],\n"
+    "  \"value_string\": [],\n"
     "  \"value_bytes\": [\n"
     "    \"AA==\",\n"                   /* "\0" */
     "    \"cXdlcnR5IAAgMTIzNA==\",\n"   /* "qwerty \0 12345" */
     "    \"cXdlcnR5IA==\",\n"           /* "qwerty \0" */
     "    \"ACAxMjM0NQ==\"\n"            /* "\0 12345" */
-    "  ]\n"
+    "  ],\n"
+    "  \"value_message\": []\n"
     "}"
   ;
 


### PR DESCRIPTION
According to the 'JSON Mapping' section in the proto3 Language guide
found here:

https://developers.google.com/protocol-buffers/docs/proto3#json

It is mentioned that NULL repeated fields should be converted to an
empty list.

Currently protobuf2json-c does not convert a NULL repeated field to
JSON (it simply ignores it). This patch updates the library to ensure
that NULL repeated fields are converted to empty JSON lists.